### PR TITLE
Add 'namespace' tag to Influx metrics

### DIFF
--- a/common-application/src/main/resources/application.yml
+++ b/common-application/src/main/resources/application.yml
@@ -16,4 +16,5 @@ metrics:
       auth: ${INFLUX_AUTH}
       tags:
         application: ${APPLICATION_NAME}
+        namespace: ${NAMESPACE}
 </#if>


### PR DESCRIPTION
So we can distinguish different instances vis the single core Grafana.