### PR TITLE
Delete empty sets in selection redux state

### DIFF
--- a/weyl-frontend/app/containers/HomePage/reducers/selection.js
+++ b/weyl-frontend/app/containers/HomePage/reducers/selection.js
@@ -107,6 +107,7 @@ const deleteEntries = (state) =>
 const deleteEntry = (state, feature) =>
   requireInfo(state)
   .updateIn(["ids", feature.layerId], fids => fids.delete(feature.id))
+  .update("ids", ids => (ids.get(feature.layerId).isEmpty() ? ids.delete(feature.layerId) : ids))
   .updateIn(["externalIdToFeatureId", feature.layerId],
     externalIds => (feature.externalId ? externalIds.delete(feature.externalId) : externalIds));
 


### PR DESCRIPTION
This fixes a subtle bug that got introduced at some point.

The SelectionPane decides whether to draw histograms based on how many different layers are currently selected.  But we weren't deleting layerIds from the selection state once they contained no features.  So if you did (1) Select borough, (2) Add jamcam to selection (3) Remove borough from selection, you'd still get histogram view, rather than sweet camera view.