### PR TITLE
Make chart look ok with blueprint

### DIFF
--- a/weyl-frontend/app/app.js
+++ b/weyl-frontend/app/app.js
@@ -29,6 +29,7 @@ import { FocusStyleManager } from "@blueprintjs/core";
 FocusStyleManager.onlyShowFocusOnTabs();      // To avoid annoying blue outlines
 import "roboto-fontface/css/roboto/roboto-fontface.css";
 require("semantic-ui/dist/semantic");
+import "./plottable.css.global";
 
 // Create redux store with history
 const underlyingHistory = createMemoryHistory();

--- a/weyl-frontend/app/components/Chart/index.js
+++ b/weyl-frontend/app/components/Chart/index.js
@@ -4,7 +4,6 @@ import {
 } from "@blueprintjs/core";
 import SizeMe from "react-sizeme";
 import * as Plottable from "plottable";
-import "plottable/plottable.css";
 import NormalPicker from "../NormalPicker";
 import Pane from "../Pane";
 import styles from "./styles.css";

--- a/weyl-frontend/app/plottable.css.global
+++ b/weyl-frontend/app/plottable.css.global
@@ -1,0 +1,224 @@
+
+.plottable-colors-0 {
+  background-color: #5279c7; /* INDIGO */
+}
+
+.plottable-colors-1 {
+  background-color: #fd373e; /* CORAL_RED */
+}
+
+.plottable-colors-2 {
+  background-color: #63c261; /* FERN */
+}
+
+.plottable-colors-3 {
+  background-color: #fad419; /* BRIGHT_SUN */
+}
+
+.plottable-colors-4 {
+  background-color: #2c2b6f; /* JACARTA */
+}
+
+.plottable-colors-5 {
+  background-color: #ff7939; /* BURNING_ORANGE */
+}
+
+.plottable-colors-6 {
+  background-color: #db2e65; /* CERISE_RED */
+}
+
+.plottable-colors-7 {
+  background-color: #99ce50; /* CONIFER */
+}
+
+.plottable-colors-8 {
+  background-color: #962565; /* ROYAL_HEATH */
+}
+
+.plottable-colors-9 {
+  background-color: #06cccc; /* ROBINS_EGG_BLUE */
+}
+
+svg.plottable {
+  display : block; /* SVGs must be block elements for width/height calculations to work in Firefox. */
+  pointer-events: visibleFill;
+}
+
+.plottable .background-fill {
+  fill: none;
+  pointer-events: none;
+}
+
+.plottable .bounding-box {
+  /* Invisible pink bounding-box to allow for collision testing */
+  fill: pink;
+  visibility: hidden;
+}
+
+.plottable .label text {
+  font-family: "Helvetica Neue", sans-serif;
+  fill: #f5f8fa;
+}
+
+.plottable .bar-label-text-area text {
+  font-family: "Helvetica Neue", sans-serif;
+  font-size: 14px;
+}
+
+.plottable .label-area text {
+  fill: #f5f8fa;
+  font-family: "Helvetica Neue", sans-serif;
+  font-size: 14px;
+}
+
+.plottable .light-label text {
+  fill: #f5f8fa;
+}
+
+.plottable .dark-label text {
+  fill: #f5f8fa;
+}
+
+.plottable .off-bar-label text {
+  fill: #f5f8fa;
+}
+
+.plottable .stacked-bar-plot .off-bar-label {
+  /* HACKHACK #2795: correct off-bar label logic to be implemented on StackedBar */
+  visibility: hidden !important;
+}
+
+.plottable .axis-label text {
+  font-size: 10px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: normal;
+  text-transform: uppercase;
+}
+
+.plottable .title-label text {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.plottable .axis line.baseline {
+  stroke: #CCC;
+  stroke-width: 1px;
+}
+
+.plottable .axis line.tick-mark {
+  stroke: #CCC;
+  stroke-width: 1px;
+}
+
+.plottable .axis text {
+  fill: #f5f8fa;
+  font-family: "Helvetica Neue", sans-serif;
+  font-size: 12px;
+  font-weight: 200;
+  line-height: normal;
+}
+
+.plottable .axis .annotation-circle {
+  fill: white;
+  stroke-width: 1px;
+  stroke: #CCC;
+}
+
+.plottable .axis .annotation-line {
+  stroke: #CCC;
+  stroke-width: 1px;
+}
+
+.plottable .axis .annotation-rect {
+  stroke: #CCC;
+  stroke-width: 1px;
+  fill: white;
+}
+
+.plottable .bar-plot .baseline {
+  stroke: #999;
+}
+
+.plottable .gridlines line {
+  stroke: #3C3C3C; /* hackhack: gridlines should be solid; see #820 */
+  opacity: 0.25;
+  stroke-width: 1px;
+}
+
+.plottable .selection-box-layer .selection-area {
+  fill: black;
+  fill-opacity: 0.03;
+  stroke: #CCC;
+}
+/* DragBoxLayer */
+.plottable .drag-box-layer.x-resizable .drag-edge-lr {
+  cursor: ew-resize;
+}
+.plottable .drag-box-layer.y-resizable .drag-edge-tb {
+  cursor: ns-resize;
+}
+
+.plottable .drag-box-layer.x-resizable.y-resizable .drag-corner-tl {
+  cursor: nwse-resize;
+}
+.plottable .drag-box-layer.x-resizable.y-resizable .drag-corner-tr {
+  cursor: nesw-resize;
+}
+.plottable .drag-box-layer.x-resizable.y-resizable .drag-corner-bl {
+  cursor: nesw-resize;
+}
+.plottable .drag-box-layer.x-resizable.y-resizable .drag-corner-br {
+  cursor: nwse-resize;
+}
+
+.plottable .drag-box-layer.movable .selection-area {
+  cursor: move; /* IE fallback */
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+  cursor: grab;
+}
+
+.plottable .drag-box-layer.movable .selection-area:active {
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+  cursor: grabbing;
+}
+/* /DragBoxLayer */
+
+.plottable .guide-line-layer line.guide-line {
+  stroke: #CCC;
+  stroke-width: 1px;
+}
+
+.plottable .drag-line-layer.enabled.vertical line.drag-edge {
+  cursor: ew-resize;
+}
+
+.plottable .drag-line-layer.enabled.horizontal line.drag-edge {
+  cursor: ns-resize;
+}
+
+.plottable .legend text {
+  fill: #f5f8fa;
+  font-family: "Helvetica Neue", sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: normal;
+}
+
+.plottable .interpolated-color-legend rect.swatch-bounding-box {
+  fill: none;
+  stroke: #CCC;
+  stroke-width: 1px;
+  pointer-events: none;
+}
+
+.plottable .waterfall-plot line.connector {
+  stroke: #CCC;
+  stroke-width: 1px;
+}
+
+.plottable .pie-plot .arc.outline {
+  stroke-linejoin: round;
+}

--- a/weyl-frontend/internals/webpack/webpack.base.babel.js
+++ b/weyl-frontend/internals/webpack/webpack.base.babel.js
@@ -33,6 +33,11 @@ module.exports = (options) => ({
       include: /node_modules/,
       loaders: ['style-loader', 'css-loader'],
     }, {
+      // CSS files named appropriately get loaded into global scope (for plottable)
+      test: /\.css.global$/,
+      exclude: /node_modules/,
+      loaders: ['style-loader', 'css-loader'],
+    }, {
       test: /\.(eot|svg|ttf|woff|woff2)$/,
       loader: 'file-loader',
     }, {


### PR DESCRIPTION
- Added a webpack rule for global css files (i.e. they won't get name mangled by webpack). This applies to all files named `.global.css`.
- Copied `plottable.css` from the plottable distro and rethemed to match blueprint