### PR TITLE
Vector tile resource should 204 on empty tiles

### DIFF
--- a/weyl-application/src/main/java/io/quartic/weyl/resource/TileResource.java
+++ b/weyl-application/src/main/java/io/quartic/weyl/resource/TileResource.java
@@ -27,13 +27,18 @@ public class TileResource {
     @Path("/{layerId}/{z}/{x}/{y}.pbf")
     @CacheControl(maxAge = 60*60)
     public byte[] protobuf(@PathParam("layerId") LayerId layerId,
-                           @PathParam("z") Integer z,
-                           @PathParam("x") Integer x,
-                           @PathParam("y") Integer y) throws ParseException, IOException {
+                             @PathParam("z") Integer z,
+                             @PathParam("x") Integer x,
+                             @PathParam("y") Integer y) throws ParseException, IOException {
         Layer layer = layerStore.getLayer(layerId)
                 .orElseThrow(() -> new NotFoundException("No layer with id: " + layerId));
 
-        return new VectorTileRenderer(ImmutableList.of(layer))
+        byte[] data = new VectorTileRenderer(ImmutableList.of(layer))
                 .render(z, x, y);
+        if (data.length == 0) {
+            return null;
+        }
+
+        return data;
     }
 }


### PR DESCRIPTION
Currently the library we're using returns an empty byte array when there are no features in a tile. Detect this case in the resource method and explicitly return null (204).

This fixes a (probably harmless) frontend error from mapbox gl