### PR TITLE
Add '--console=plain' to Circle Gradle commands

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,11 +11,11 @@ dependencies:
     - weyl-frontend/node_modules
     - management-frontend/node_modules
   override:
-    - ./gradlew resolveConfigurations npmInstall --parallel
+    - ./gradlew resolveConfigurations npmInstall --parallel --console=plain
 
 test:
   override:
-    - ./gradlew check docker --parallel --info
+    - ./gradlew check docker --parallel --info --console=plain
   post:
     - mkdir -p ${CIRCLE_TEST_REPORTS}/junit/
     - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ${CIRCLE_TEST_REPORTS}/junit/ \;
@@ -25,4 +25,4 @@ deployment:
     branch: /.*/
     commands:
       - curl https://raw.githubusercontent.com/quartictech/circleci-utils/develop/circleci-gcloud-login | bash
-      - ./gradlew dockerPush --parallel --info
+      - ./gradlew dockerPush --parallel --info --console=plain


### PR DESCRIPTION
Minor aesthetic improvement to CircleCI build logs (gets rid of all the "building 70%", etc. noise.