### PR TITLE
Cache top-level .gradle dir

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
 
 dependencies:
   cache_directories:
+    - .gradle
     - weyl-frontend/.gradle/nodejs
     - management-frontend/.gradle/nodejs
     - weyl-frontend/node_modules


### PR DESCRIPTION
This shaves 40-50 seconds off our Circle build times.

Rationale is that Gradle caches dependency hashes in `.gradle` dir - if these are missing then various tasks in the Circle `dependencies` phase get re-run rather than skipped (e.g. `npmSetup`).