### PR TITLE
Remove dataDir parameter from default config to workaround terriblenees

### DIFF
--- a/howl-application/howl.yml
+++ b/howl-application/howl.yml
@@ -1,6 +1,5 @@
 storage:
   type: local_disk
-  dataDir: ./data
 
 server:
   applicationContextPath: /

--- a/howl-application/src/main/java/io/quartic/howl/DiskStorageBackendConfig.java
+++ b/howl-application/src/main/java/io/quartic/howl/DiskStorageBackendConfig.java
@@ -6,7 +6,7 @@ import io.quartic.howl.storage.StorageBackend;
 import java.nio.file.Paths;
 
 public class DiskStorageBackendConfig implements StorageBackendConfig {
-    private String dataDir;
+    private String dataDir = "./data";
 
     public void setDataDir(String dataDir) {
         this.dataDir = dataDir;


### PR DESCRIPTION
The way we deploy our code in k8s doesn't allow us to remove parameters from the default shipped config file.

To workaround:
- Remove `dataDir` parameter from local disk storage config in default `howl.yml`
- Make it default to `./data/`