### PR TITLE
Make Weyl save to weyl-export namespace (to avoid reabsorbing saved d…

### DIFF
--- a/weyl-application/src/main/java/io/quartic/weyl/WeylApplication.java
+++ b/weyl-application/src/main/java/io/quartic/weyl/WeylApplication.java
@@ -113,7 +113,7 @@ public class WeylApplication extends ApplicationBase<WeylConfiguration> {
         environment.jersey().register(computeResource);
         environment.jersey().register(new TileResource(snapshotSequences));
         environment.jersey().register(alertResource);
-        environment.jersey().register(createLayerExportResource(snapshotSequences, howlClient, catalogueService, configuration.getDefaultCatalogueNamespace()));
+        environment.jersey().register(createLayerExportResource(snapshotSequences, howlClient, catalogueService, configuration.getExportCatalogueNamespace()));
 
         websocketBundle.addEndpoint(serverEndpointConfig("/ws",
                 createWebsocketEndpoint(snapshotSequences, alertResource, configuration.getMap())));
@@ -167,13 +167,13 @@ public class WeylApplication extends ApplicationBase<WeylConfiguration> {
             Observable<LayerSnapshotSequence> layerSnapshotSequences,
             HowlClient howlClient,
             CatalogueService catalogueService,
-            DatasetNamespace defaultCatalogueNamespace
+            DatasetNamespace exportCatalogueNamespace
     ) {
         LayerExporter layerExporter = new LayerExporter(
                 layerSnapshotSequences,
                 new HowlGeoJsonLayerWriter(howlClient, featureConverter()),
                 catalogueService,
-                defaultCatalogueNamespace);
+                exportCatalogueNamespace);
         return new LayerExportResource(layerExporter);
     }
 

--- a/weyl-application/src/main/java/io/quartic/weyl/WeylConfiguration.kt
+++ b/weyl-application/src/main/java/io/quartic/weyl/WeylConfiguration.kt
@@ -32,5 +32,9 @@ class WeylConfiguration : Configuration() {
 
     @Valid
     @NotNull
+    var exportCatalogueNamespace: DatasetNamespace? = null
+
+    @Valid
+    @NotNull
     var map: MapConfig? = null
 }

--- a/weyl-application/weyl.yml
+++ b/weyl-application/weyl.yml
@@ -6,7 +6,8 @@ catalogue:
 howlStorageUrl: http://localhost:8120/api
 rainWsUrlRoot: ws://localhost:8150/ws
 
-defaultCatalogueNamespace: weyl-export
+defaultCatalogueNamespace: production
+exportCatalogueNamespace: weyl-export
 
 # All of London
 map:


### PR DESCRIPTION
…ata)