### PR TITLE
Try a different decoder

### DIFF
--- a/common-core/src/main/kotlin/io/quartic/common/secrets/Utils.kt
+++ b/common-core/src/main/kotlin/io/quartic/common/secrets/Utils.kt
@@ -4,7 +4,7 @@ import org.apache.commons.codec.binary.Hex
 import java.security.SecureRandom
 import java.util.*
 
-fun String.decodeAsBase64(): ByteArray = Base64.getDecoder().decode(this)
+fun String.decodeAsBase64(): ByteArray = Base64.getMimeDecoder().decode(this)
 fun ByteArray.encodeAsBase64(): String = Base64.getEncoder().encodeToString(this)
 fun ByteArray.encodeAsString(): String = String(this)
 


### PR DESCRIPTION
Seems to fix secret decoding from env vars on kubernetes. Got the idea from here: https://stackoverflow.com/questions/35292836/base64-input-byte-array-has-incorrect-ending-byte-at-40 

Not sure why this works.