### PR TITLE
Fix terrible noobug in GCS

### DIFF
--- a/howl/src/main/kotlin/io/quartic/howl/storage/GcsStorageFactory.kt
+++ b/howl/src/main/kotlin/io/quartic/howl/storage/GcsStorageFactory.kt
@@ -60,7 +60,8 @@ class GcsStorageFactory {
             StorageMetadata(
                 Instant.ofEpochMilli(response.updated.value),
                 response.contentType ?: DEFAULT_MIME_TYPE,
-                response.size.toLong()
+                // Probably OK for now!
+                response.getSize().toLong()
             )
         }
 


### PR DESCRIPTION
Using wrong `size` field in GCS lead to invalid `Content-Length` and truncated files.