### PR TITLE
Bump to Jackson 2.9.1 (and thus DW 1.2.0 and JJWT 0.8.0)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,9 +10,9 @@ def kotlinVersion = "1.1.50"
 
 dependencies {
     compile gradleApi()
-    compile "com.fasterxml.jackson.core:jackson-annotations:2.8.7"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.8.7"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.8.7"
+    compile "com.fasterxml.jackson.core:jackson-annotations:2.9.1"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.1"
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.1"
 
     // Plugin dependencies
     compile "com.netflix.nebula:nebula-kotlin-plugin:${kotlinVersion}"

--- a/common-application/src/main/kotlin/io/quartic/common/application/ConfigurationBase.kt
+++ b/common-application/src/main/kotlin/io/quartic/common/application/ConfigurationBase.kt
@@ -1,6 +1,5 @@
 package io.quartic.common.application
 
-import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -30,7 +29,7 @@ abstract class ConfigurationBase : Configuration() {
     var url: ServerDetails = ServerDetails()
         set(value) = configureServer(value)
 
-    var logLevel: Level = Level.INFO
+    var logLevel: String = "INFO"
         set(value) = configureLogging(value)
 
     val secretsCodec by lazy {
@@ -55,7 +54,7 @@ abstract class ConfigurationBase : Configuration() {
     }
 
     // Opinionated logging configuration
-    private fun configureLogging(level: Level) {
+    private fun configureLogging(level: String) {
         super.setLoggingFactory(DefaultLoggingFactory().apply {
             this.level = level
             setAppenders(listOf(ConsoleAppenderFactory<ILoggingEvent>().apply {

--- a/common-core/build.gradle
+++ b/common-core/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     compile "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     compile "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
-    compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.8.7" // Hardcode this version due to needing support for default values (see https://github.com/FasterXML/jackson-module-kotlin)
+    compile "com.fasterxml.jackson.module:jackson-module-kotlin:${versions.jackson}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson}"
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,8 +3,8 @@ ext {
     libraries = [:]
 }
 
-versions.dropwizard = "1.1.0"
-versions.jackson = "2.8.7"      // This is the Jackson version that Dropwizard currently pulls in
+versions.dropwizard = "1.2.0"
+versions.jackson = "2.9.1"      // This is the Jackson version that Dropwizard currently pulls in
 versions.coroutines = "0.17"
 versions.retrofit = "2.3.0"
 versions.vertx = "3.4.2"
@@ -16,7 +16,7 @@ libraries.coroutines = [
     "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}",
     "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${versions.coroutines}",
 ]
-libraries.jjwt = "io.jsonwebtoken:jjwt:0.7.0"
+libraries.jjwt = "io.jsonwebtoken:jjwt:0.8.0"
 libraries.junit = "junit:junit:4.12"
 libraries.wiremock = "com.github.tomakehurst:wiremock:2.7.1"
 libraries.embeddedPostgres = "com.opentable.components:otj-pg-embedded:0.9.0"


### PR DESCRIPTION
I stumbled across [CVE-2017-4995](https://pivotal.io/security/cve-2017-4995) which shouldn't affect us, but better to be on the safe side.